### PR TITLE
Adding validation to _writeCharacteristic _printer in iOS

### DIFF
--- a/ios/RNZebraBluetoothPrinter.m
+++ b/ios/RNZebraBluetoothPrinter.m
@@ -102,23 +102,31 @@ RCT_EXPORT_METHOD(print:(NSString*)zpl
 {
     NSLog(@"print called %@",_writeCharacteristic);
     NSLog(@"print calles %@",_printer);
-  self.printResolveBlock=resolve;
-  self.printRejectBlock=reject;
-  NSString *szpl = [zpl stringByAppendingString:@"\r\n"];
-    const char *bytes = [szpl UTF8String];
-    size_t len = [szpl length];
-    NSData *payload = [NSData dataWithBytes:bytes length:len];
-    NSUInteger length = [payload length];
-    NSUInteger chunkSize = 50;
-    NSUInteger offset = 0;
-do {
-    NSUInteger thisChunkSize = length - offset > chunkSize ? chunkSize : length - offset;
-    NSData* chunk = [NSData dataWithBytesNoCopy:(char *)[payload bytes] + offset  
-                    length:thisChunkSize  freeWhenDone:NO];
-                    offset += thisChunkSize;
-    [self.printer writeValue:chunk forCharacteristic:self.writeCharacteristic type:CBCharacteristicWriteWithResponse];
-} while (offset < length);
-  printCompleted = YES; 
+    if (!_writeCharacteristic  && !_printer ){
+        NSLog(@"print error");  
+        resolve(@"false");
+        self.printResolveBlock = nil;
+        self.printRejectBlock=nil;
+        printCompleted= NO;
+    } else {
+        self.printResolveBlock=resolve;
+        self.printRejectBlock=reject;
+        NSString *szpl = [zpl stringByAppendingString:@"\r\n"];
+        const char *bytes = [szpl UTF8String];
+        size_t len = [szpl length];
+        NSData *payload = [NSData dataWithBytes:bytes length:len];
+        NSUInteger length = [payload length];
+        NSUInteger chunkSize = 50;
+        NSUInteger offset = 0;
+        do {
+            NSUInteger thisChunkSize = length - offset > chunkSize ? chunkSize : length - offset;
+            NSData* chunk = [NSData dataWithBytesNoCopy:(char *)[payload bytes] + offset  
+                            length:thisChunkSize  freeWhenDone:NO];
+                            offset += thisChunkSize;
+            [self.printer writeValue:chunk forCharacteristic:self.writeCharacteristic type:CBCharacteristicWriteWithResponse];
+        } while (offset < length);
+        printCompleted = YES; 
+    }
 }
 
 


### PR DESCRIPTION
When I'm trying to print in iOS after several minutes these objects are nil and the print process never ends, so I need this validation to send a message in the UI to connect the printer again